### PR TITLE
Add HR snapshot attendance reporting

### DIFF
--- a/app/staff/views.py
+++ b/app/staff/views.py
@@ -3183,6 +3183,227 @@ def hr_login_summary_report():
     )
 
 
+@staff.route('/for-hr/daily-attendance-report')
+@hr_permission.require()
+@login_required
+def hr_daily_attendance_report():
+    today = datetime.now(tz).date()
+    default_start = today.replace(day=1)
+    staff_type = request.args.get('staff_type', 'all')
+    if staff_type not in {'all', 'academic', 'non_academic'}:
+        staff_type = 'all'
+    selected_org_id = request.args.get('org_id', type=int)
+
+    def parse_date(value, default):
+        if not value:
+            return default
+        try:
+            return datetime.strptime(value, '%Y-%m-%d').date()
+        except ValueError:
+            return default
+
+    start_date = parse_date(request.args.get('start'), default_start)
+    end_date = parse_date(request.args.get('end'), today)
+    if start_date > end_date:
+        start_date, end_date = end_date, start_date
+
+    staff_type_filter = None
+    if staff_type == 'academic':
+        staff_type_filter = StaffPersonalInfo.academic_staff.is_(True)
+    elif staff_type == 'non_academic':
+        staff_type_filter = or_(
+            StaffPersonalInfo.academic_staff.is_(False),
+            StaffPersonalInfo.academic_staff.is_(None),
+        )
+    snapshot_filters = [
+        StaffDailyAttendance.attendance_date.between(start_date, end_date),
+        *_active_staff_filters(),
+    ]
+    if selected_org_id:
+        snapshot_filters.append(StaffPersonalInfo.org_id == selected_org_id)
+    if staff_type_filter is not None:
+        snapshot_filters.append(staff_type_filter)
+
+    grouped_rows = (
+        db.session.query(
+            StaffDailyAttendance.attendance_date,
+            StaffDailyAttendance.status,
+            func.count(StaffDailyAttendance.id),
+        )
+        .join(StaffAccount, StaffDailyAttendance.staff_id == StaffAccount.id)
+        .join(StaffPersonalInfo, StaffAccount.personal_id == StaffPersonalInfo.id)
+        .filter(*snapshot_filters)
+        .group_by(StaffDailyAttendance.attendance_date, StaffDailyAttendance.status)
+        .order_by(StaffDailyAttendance.attendance_date.asc())
+        .all()
+    )
+
+    status_order = ('present', 'absent', 'leave', 'work_from_home', 'holiday')
+    status_labels = {
+        'present': 'ลงเวลาปกติ',
+        'absent': 'ไม่พบการลงเวลา',
+        'leave': 'ลา',
+        'work_from_home': 'ทำงานที่บ้าน',
+        'holiday': 'วันหยุด',
+    }
+    counts_by_date = defaultdict(lambda: defaultdict(int))
+    totals = defaultdict(int)
+    for attendance_date, status, count in grouped_rows:
+        counts_by_date[attendance_date][status] = int(count)
+        totals[status] += int(count)
+
+    source_rows = (
+        db.session.query(
+            StaffDailyAttendance.source,
+            func.count(StaffDailyAttendance.id),
+        )
+        .join(StaffAccount, StaffDailyAttendance.staff_id == StaffAccount.id)
+        .join(StaffPersonalInfo, StaffAccount.personal_id == StaffPersonalInfo.id)
+        .filter(*snapshot_filters)
+        .group_by(StaffDailyAttendance.source)
+        .all()
+    )
+    source_counts = defaultdict(int)
+    for source, count in source_rows:
+        source_counts[source or 'unknown'] = int(count)
+
+    staff_snapshot_rows = (
+        db.session.query(StaffDailyAttendance, StaffPersonalInfo)
+        .join(StaffAccount, StaffDailyAttendance.staff_id == StaffAccount.id)
+        .join(StaffPersonalInfo, StaffAccount.personal_id == StaffPersonalInfo.id)
+        .filter(*snapshot_filters)
+        .order_by(StaffPersonalInfo.th_firstname.asc(), StaffPersonalInfo.en_firstname.asc())
+        .all()
+    )
+    staff_rows_by_id = {}
+    for snapshot, personal_info in staff_snapshot_rows:
+        row = staff_rows_by_id.setdefault(snapshot.staff_id, {
+            'staff_id': snapshot.staff_id,
+            'name': personal_info.fullname,
+            'normal_checkin': 0,
+            'approved_request': 0,
+            'hr_manual': 0,
+            'other_present': 0,
+            'absent': 0,
+            'leave': 0,
+            'work_from_home': 0,
+            'holiday': 0,
+            'total': 0,
+        })
+        row['total'] += 1
+        if snapshot.status == 'present':
+            if snapshot.source == 'approved_request':
+                row['approved_request'] += 1
+            elif snapshot.source == 'hr_manual':
+                row['hr_manual'] += 1
+            elif snapshot.source in (None, 'scan'):
+                row['normal_checkin'] += 1
+            else:
+                row['other_present'] += 1
+        elif snapshot.status in row:
+            row[snapshot.status] += 1
+
+    staff_rows = sorted(staff_rows_by_id.values(), key=lambda row: row['name'])
+    active_org_ids = [
+        org_id for (org_id,) in (
+            db.session.query(StaffPersonalInfo.org_id)
+            .join(StaffAccount, StaffPersonalInfo.id == StaffAccount.personal_id)
+            .filter(*_active_staff_filters())
+            .filter(StaffPersonalInfo.org_id.isnot(None))
+            .distinct()
+            .all()
+        )
+    ]
+    organizations = (
+        Org.query
+        .filter(Org.id.in_(active_org_ids))
+        .order_by(Org.name.asc())
+        .all()
+        if active_org_ids else []
+    )
+
+    daily_rows = []
+    current_date = start_date
+    while current_date <= end_date:
+        date_counts = counts_by_date[current_date]
+        daily_rows.append({
+            'date': current_date,
+            'counts': {status: date_counts.get(status, 0) for status in status_order},
+            'total': sum(date_counts.values()),
+        })
+        current_date += timedelta(days=1)
+
+    snapshot_rows = sum(totals.values())
+    staff_count = (
+        db.session.query(func.count(func.distinct(StaffDailyAttendance.staff_id)))
+        .join(StaffAccount, StaffDailyAttendance.staff_id == StaffAccount.id)
+        .join(StaffPersonalInfo, StaffAccount.personal_id == StaffPersonalInfo.id)
+        .filter(*snapshot_filters)
+        .scalar()
+    ) or 0
+
+    return render_template(
+        'staff/hr_daily_attendance_report.html',
+        start_date=start_date,
+        end_date=end_date,
+        staff_type=staff_type,
+        organizations=organizations,
+        selected_org_id=selected_org_id,
+        status_order=status_order,
+        status_labels=status_labels,
+        totals=totals,
+        source_counts=source_counts,
+        snapshot_rows=snapshot_rows,
+        staff_count=staff_count,
+        staff_rows=staff_rows,
+        daily_rows=daily_rows,
+    )
+
+
+@staff.route('/for-hr/daily-attendance-report/staff/<int:staff_id>')
+@hr_permission.require()
+@login_required
+def hr_daily_attendance_staff_detail(staff_id):
+    today = datetime.now(tz).date()
+    default_start = today.replace(day=1)
+
+    def parse_date(value, default):
+        if not value:
+            return default
+        try:
+            return datetime.strptime(value, '%Y-%m-%d').date()
+        except ValueError:
+            return default
+
+    start_date = parse_date(request.args.get('start'), default_start)
+    end_date = parse_date(request.args.get('end'), today)
+    if start_date > end_date:
+        start_date, end_date = end_date, start_date
+
+    staff_account = (
+        StaffAccount.query
+        .join(StaffPersonalInfo, StaffAccount.personal_id == StaffPersonalInfo.id)
+        .filter(StaffAccount.id == staff_id, *_active_staff_filters())
+        .first_or_404()
+    )
+    records = (
+        StaffDailyAttendance.query
+        .filter(
+            StaffDailyAttendance.staff_id == staff_id,
+            StaffDailyAttendance.attendance_date.between(start_date, end_date),
+        )
+        .order_by(StaffDailyAttendance.attendance_date.desc())
+        .all()
+    )
+    return render_template(
+        'staff/hr_daily_attendance_staff_detail.html',
+        staff_account=staff_account,
+        records=records,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
 @staff.route('/for-hr/login-report/checkin-requests')
 @hr_permission.require()
 @login_required

--- a/app/templates/staff/hr_daily_attendance_report.html
+++ b/app/templates/staff/hr_daily_attendance_report.html
@@ -1,0 +1,327 @@
+{% extends "base.html" %}
+{% include "staff/nav.html" %}
+
+{% block title %}สถิติการลงเวลาจากข้อมูลสรุปรายวัน{% endblock %}
+
+{% block page_content %}
+<style>
+    .daily-attendance-report {
+        padding: 2rem 0 4rem;
+    }
+
+    .daily-attendance-report-card {
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(245, 247, 252, 0.96));
+        border: 1px solid rgba(18, 39, 84, 0.08);
+        border-radius: 24px;
+        box-shadow: 0 18px 50px rgba(18, 39, 84, 0.08);
+        margin: 0 auto;
+        max-width: 78rem;
+        padding: 1.5rem;
+    }
+
+    .daily-attendance-report-title {
+        color: var(--theme-navy-deep);
+        font-size: 1.45rem;
+        font-weight: 800;
+        margin: 0;
+    }
+
+    .daily-attendance-report-subtitle {
+        color: var(--theme-muted);
+        margin: 0.35rem 0 0;
+    }
+
+    .daily-attendance-report-filters {
+        align-items: end;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-top: 1.25rem;
+    }
+
+    .daily-attendance-report-filter {
+        flex: 1 1 14rem;
+    }
+
+    .daily-attendance-report-filter label {
+        color: var(--theme-muted);
+        display: block;
+        font-size: 0.75rem;
+        font-weight: 700;
+        margin-bottom: 0.3rem;
+    }
+
+    .daily-attendance-report-filter input {
+        border: 1px solid rgba(18, 39, 84, 0.14);
+        border-radius: 10px;
+        font: inherit;
+        min-height: 2.5rem;
+        padding: 0.45rem 0.65rem;
+        width: 100%;
+    }
+
+    .daily-attendance-report-filter select {
+        background: #fff;
+        border: 1px solid rgba(18, 39, 84, 0.14);
+        border-radius: 10px;
+        font: inherit;
+        min-height: 2.5rem;
+        padding: 0.45rem 0.65rem;
+        width: 100%;
+    }
+
+    .daily-attendance-report-type {
+        flex: 1 1 20rem;
+    }
+
+    .daily-attendance-report-type legend {
+        color: var(--theme-muted);
+        font-size: 0.75rem;
+        font-weight: 700;
+        margin-bottom: 0.3rem;
+    }
+
+    .daily-attendance-report-type-options {
+        align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        min-height: 2.5rem;
+    }
+
+    .daily-attendance-report-type-options label {
+        color: var(--theme-navy-deep);
+        cursor: pointer;
+        font-size: 0.9rem;
+    }
+
+    .daily-attendance-report-type-options input {
+        margin-right: 0.25rem;
+    }
+
+    .daily-attendance-report-button {
+        background: var(--theme-navy-deep);
+        border: 0;
+        border-radius: 10px;
+        color: #fff;
+        cursor: pointer;
+        font: inherit;
+        font-weight: 700;
+        min-height: 2.5rem;
+        padding: 0.45rem 1rem;
+    }
+
+    .daily-attendance-report-link {
+        display: inline-block;
+        margin-top: 0.85rem;
+    }
+
+    .daily-attendance-report-summary {
+        display: grid;
+        gap: 0.75rem;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        margin-top: 1.5rem;
+    }
+
+    .daily-attendance-report-stat {
+        background: rgba(255, 255, 255, 0.8);
+        border: 1px solid rgba(18, 39, 84, 0.08);
+        border-radius: 16px;
+        padding: 1rem;
+    }
+
+    .daily-attendance-report-stat-label {
+        color: var(--theme-muted);
+        display: block;
+        font-size: 0.78rem;
+        font-weight: 700;
+    }
+
+    .daily-attendance-report-stat-value {
+        color: var(--theme-navy-deep);
+        display: block;
+        font-size: 1.55rem;
+        font-weight: 800;
+        margin-top: 0.25rem;
+    }
+
+    .daily-attendance-report-table-wrap {
+        margin-top: 1.5rem;
+        overflow-x: auto;
+    }
+
+    .daily-attendance-report-table {
+        background: rgba(255, 255, 255, 0.86);
+        border: 1px solid rgba(18, 39, 84, 0.08);
+        border-collapse: separate;
+        border-radius: 14px;
+        border-spacing: 0;
+        min-width: 54rem;
+        overflow: hidden;
+        width: 100%;
+    }
+
+    .daily-attendance-report-table th,
+    .daily-attendance-report-table td {
+        border-bottom: 1px solid rgba(18, 39, 84, 0.08);
+        padding: 0.65rem 0.75rem;
+        text-align: right;
+    }
+
+    .daily-attendance-report-table th:first-child,
+    .daily-attendance-report-table td:first-child {
+        text-align: left;
+    }
+
+    .daily-attendance-report-table th {
+        background: rgba(18, 39, 84, 0.05);
+        color: var(--theme-muted);
+        font-size: 0.72rem;
+        font-weight: 800;
+    }
+
+    .daily-attendance-report-table td {
+        color: var(--theme-navy-deep);
+        font-size: 0.82rem;
+    }
+
+    .daily-attendance-report-table tr:last-child td {
+        border-bottom: 0;
+    }
+
+    @media (max-width: 700px) {
+        .daily-attendance-report-summary {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>
+
+<section class="section daily-attendance-report">
+    <div class="daily-attendance-report-card">
+        <h1 class="daily-attendance-report-title">สถิติการลงเวลาจากข้อมูลสรุปรายวัน</h1>
+        <p class="daily-attendance-report-subtitle">
+            สรุปสถานะจาก check-in snapshot ของบุคลากรที่ยังปฏิบัติงานในช่วงวันที่เลือก
+        </p>
+
+        <form class="daily-attendance-report-filters" method="get">
+            <div class="daily-attendance-report-filter">
+                <label for="dailyAttendanceStart">วันที่เริ่มต้น</label>
+                <input id="dailyAttendanceStart" name="start" type="date"
+                       value="{{ start_date.isoformat() }}" required>
+            </div>
+            <div class="daily-attendance-report-filter">
+                <label for="dailyAttendanceEnd">วันที่สิ้นสุด</label>
+                <input id="dailyAttendanceEnd" name="end" type="date"
+                       value="{{ end_date.isoformat() }}" required>
+            </div>
+            <div class="daily-attendance-report-filter">
+                <label for="dailyAttendanceOrganization">หน่วยงาน</label>
+                <select id="dailyAttendanceOrganization" name="org_id">
+                    <option value="">ทุกหน่วยงาน</option>
+                    {% for organization in organizations %}
+                        <option value="{{ organization.id }}"
+                                {% if selected_org_id == organization.id %}selected{% endif %}>
+                            {{ organization.display_name }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <fieldset class="daily-attendance-report-type">
+                <legend>ประเภทบุคลากร</legend>
+                <div class="daily-attendance-report-type-options">
+                    <label><input type="radio" name="staff_type" value="all"
+                                  {% if staff_type == 'all' %}checked{% endif %}> ทั้งหมด</label>
+                    <label><input type="radio" name="staff_type" value="academic"
+                                  {% if staff_type == 'academic' %}checked{% endif %}> สายวิชาการ</label>
+                    <label><input type="radio" name="staff_type" value="non_academic"
+                                  {% if staff_type == 'non_academic' %}checked{% endif %}> สายสนับสนุน</label>
+                </div>
+            </fieldset>
+            <button class="daily-attendance-report-button" type="submit">
+                <i class="fas fa-chart-column" aria-hidden="true"></i>
+                แสดงสถิติ
+            </button>
+        </form>
+
+        <a class="daily-attendance-report-link" href="{{ url_for('staff.hr_login_summary_report') }}">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i> กลับหน้าสรุปการเข้าออกงาน
+        </a>
+
+        <div class="daily-attendance-report-summary">
+            <div class="daily-attendance-report-stat">
+                <span class="daily-attendance-report-stat-label">จำนวนวัน</span>
+                <strong class="daily-attendance-report-stat-value">{{ daily_rows|length }}</strong>
+            </div>
+            <div class="daily-attendance-report-stat">
+                <span class="daily-attendance-report-stat-label">บุคลากรที่พบใน snapshot</span>
+                <strong class="daily-attendance-report-stat-value">{{ '{:,}'.format(staff_count) }}</strong>
+            </div>
+            <div class="daily-attendance-report-stat">
+                <span class="daily-attendance-report-stat-label">รายการ snapshot ทั้งหมด</span>
+                <strong class="daily-attendance-report-stat-value">{{ '{:,}'.format(snapshot_rows) }}</strong>
+            </div>
+        </div>
+
+        <div class="daily-attendance-report-summary">
+            {% for status in status_order %}
+                <div class="daily-attendance-report-stat">
+                    <span class="daily-attendance-report-stat-label">{{ status_labels[status] }}</span>
+                    <strong class="daily-attendance-report-stat-value">{{ '{:,}'.format(totals.get(status, 0)) }}</strong>
+                </div>
+            {% endfor %}
+        </div>
+
+        <div class="daily-attendance-report-summary">
+            <div class="daily-attendance-report-stat">
+                <span class="daily-attendance-report-stat-label">อนุมัติคำขอรับรองเวลา</span>
+                <strong class="daily-attendance-report-stat-value">{{ '{:,}'.format(source_counts.get('approved_request', 0)) }}</strong>
+            </div>
+            <div class="daily-attendance-report-stat">
+                <span class="daily-attendance-report-stat-label">บันทึกโดย HR</span>
+                <strong class="daily-attendance-report-stat-value">{{ '{:,}'.format(source_counts.get('hr_manual', 0)) }}</strong>
+            </div>
+        </div>
+
+        <div class="daily-attendance-report-table-wrap">
+            <table class="daily-attendance-report-table">
+                <thead>
+                    <tr>
+                        <th>บุคลากร</th>
+                        <th>ลงเวลาปกติ</th>
+                        <th>อนุมัติคำขอ</th>
+                        <th>บันทึกโดย HR</th>
+                        <th>อื่น ๆ</th>
+                        <th>ไม่พบการลงเวลา</th>
+                        <th>ลา</th>
+                        <th>ทำงานที่บ้าน</th>
+                        <th>วันหยุด</th>
+                        <th>รวม</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in staff_rows %}
+                        <tr>
+                            <td>
+                                <a href="{{ url_for('staff.hr_daily_attendance_staff_detail', staff_id=row.staff_id, start=start_date.isoformat(), end=end_date.isoformat()) }}">
+                                    {{ row.name }}
+                                </a>
+                            </td>
+                            <td>{{ '{:,}'.format(row.normal_checkin) }}</td>
+                            <td>{{ '{:,}'.format(row.approved_request) }}</td>
+                            <td>{{ '{:,}'.format(row.hr_manual) }}</td>
+                            <td>{{ '{:,}'.format(row.other_present) }}</td>
+                            <td>{{ '{:,}'.format(row.absent) }}</td>
+                            <td>{{ '{:,}'.format(row.leave) }}</td>
+                            <td>{{ '{:,}'.format(row.work_from_home) }}</td>
+                            <td>{{ '{:,}'.format(row.holiday) }}</td>
+                            <td>{{ '{:,}'.format(row.total) }}</td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="10">ไม่พบข้อมูล snapshot ตามเงื่อนไขที่เลือก</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/app/templates/staff/hr_daily_attendance_staff_detail.html
+++ b/app/templates/staff/hr_daily_attendance_staff_detail.html
@@ -1,0 +1,204 @@
+{% extends "base.html" %}
+{% include "staff/nav.html" %}
+
+{% block title %}รายละเอียดข้อมูลสรุปรายวัน{% endblock %}
+
+{% block page_content %}
+<style>
+    .daily-attendance-detail {
+        padding: 2rem 0 4rem;
+    }
+
+    .daily-attendance-detail-card {
+        background: #fff;
+        border: 1px solid rgba(18, 39, 84, 0.08);
+        border-radius: 24px;
+        box-shadow: 0 18px 50px rgba(18, 39, 84, 0.08);
+        margin: 0 auto;
+        max-width: 78rem;
+        padding: 1.5rem;
+    }
+
+    .daily-attendance-detail-title {
+        color: var(--theme-navy-deep);
+        font-size: 1.45rem;
+        font-weight: 800;
+        margin: 0;
+    }
+
+    .daily-attendance-detail-subtitle {
+        color: var(--theme-muted);
+        margin: 0.35rem 0 0;
+    }
+
+    .daily-attendance-detail-filter {
+        align-items: end;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-top: 1.25rem;
+    }
+
+    .daily-attendance-detail-filter label {
+        color: var(--theme-muted);
+        display: block;
+        font-size: 0.75rem;
+        font-weight: 700;
+        margin-bottom: 0.3rem;
+    }
+
+    .daily-attendance-detail-filter input {
+        border: 1px solid rgba(18, 39, 84, 0.14);
+        border-radius: 10px;
+        font: inherit;
+        min-height: 2.5rem;
+        padding: 0.45rem 0.65rem;
+    }
+
+    .daily-attendance-detail-filter button {
+        background: var(--theme-navy-deep);
+        border: 0;
+        border-radius: 10px;
+        color: #fff;
+        cursor: pointer;
+        font: inherit;
+        font-weight: 700;
+        min-height: 2.5rem;
+        padding: 0.45rem 1rem;
+    }
+
+    .daily-attendance-detail-back {
+        display: inline-block;
+        margin-top: 0.85rem;
+    }
+
+    .daily-attendance-detail-table-wrap {
+        margin-top: 1.5rem;
+        overflow-x: auto;
+    }
+
+    .daily-attendance-detail-table {
+        border-collapse: separate;
+        border-spacing: 0;
+        min-width: 64rem;
+        width: 100%;
+    }
+
+    .daily-attendance-detail-table th,
+    .daily-attendance-detail-table td {
+        border-bottom: 1px solid rgba(18, 39, 84, 0.08);
+        padding: 0.7rem 0.75rem;
+        text-align: left;
+    }
+
+    .daily-attendance-detail-table th {
+        background: rgba(18, 39, 84, 0.05);
+        color: var(--theme-muted);
+        font-size: 0.72rem;
+        font-weight: 800;
+    }
+
+    .daily-attendance-detail-table td {
+        color: var(--theme-navy-deep);
+        font-size: 0.82rem;
+    }
+
+    .attendance-status-tag {
+        border-radius: 999px;
+        display: inline-flex;
+        font-size: 0.72rem;
+        font-weight: 800;
+        padding: 0.3rem 0.65rem;
+        white-space: nowrap;
+    }
+
+    .attendance-status-tag.is-present {
+        background: rgba(46, 139, 87, 0.12);
+        color: #247346;
+    }
+
+    .attendance-status-tag.is-absent {
+        background: rgba(190, 59, 59, 0.12);
+        color: #a72f2f;
+    }
+
+    .attendance-status-tag.is-leave {
+        background: rgba(210, 143, 37, 0.14);
+        color: #996516;
+    }
+
+    .attendance-status-tag.is-work-from-home {
+        background: rgba(54, 112, 181, 0.13);
+        color: #285d9b;
+    }
+
+    .attendance-status-tag.is-holiday {
+        background: rgba(125, 91, 158, 0.13);
+        color: #68458a;
+    }
+</style>
+
+<section class="section daily-attendance-detail">
+    <div class="daily-attendance-detail-card">
+        <h1 class="daily-attendance-detail-title">{{ staff_account.fullname }}</h1>
+        <p class="daily-attendance-detail-subtitle">
+            Snapshot records from {{ start_date.strftime('%d/%m/%Y') }} to {{ end_date.strftime('%d/%m/%Y') }}
+        </p>
+
+        <form class="daily-attendance-detail-filter" method="get">
+            <div>
+                <label for="detailStart">Start date</label>
+                <input id="detailStart" name="start" type="date" value="{{ start_date.isoformat() }}" required>
+            </div>
+            <div>
+                <label for="detailEnd">End date</label>
+                <input id="detailEnd" name="end" type="date" value="{{ end_date.isoformat() }}" required>
+            </div>
+            <button type="submit"><i class="fas fa-filter" aria-hidden="true"></i> Filter</button>
+        </form>
+
+        <a class="daily-attendance-detail-back"
+           href="{{ url_for('staff.hr_daily_attendance_report', start=start_date.isoformat(), end=end_date.isoformat()) }}">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i> Back to daily attendance statistics
+        </a>
+
+        <div class="daily-attendance-detail-table-wrap">
+            <table class="daily-attendance-detail-table">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Status</th>
+                        <th>Source</th>
+                        <th>First check-in</th>
+                        <th>Last checkout</th>
+                        <th>Note</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for record in records %}
+                        <tr>
+                            <td>{{ record.attendance_date.strftime('%d/%m/%Y') }}</td>
+                            <td>
+                                <span class="attendance-status-tag is-{{ record.status|replace('_', '-') }}">
+                                {% if record.status == 'present' %}Present
+                                {% elif record.status == 'absent' %}Absent
+                                {% elif record.status == 'leave' %}Leave
+                                {% elif record.status == 'work_from_home' %}Work from home
+                                {% elif record.status == 'holiday' %}Holiday
+                                {% else %}{{ record.status }}{% endif %}
+                                </span>
+                            </td>
+                            <td>{% if record.source == 'attendance_reconciliation' %}{% elif record.source %}{{ record.source }}{% else %}—{% endif %}</td>
+                            <td>{{ record.first_checkin_at|localdatetime if record.first_checkin_at else '—' }}</td>
+                            <td>{{ record.last_checkout_at|localdatetime if record.last_checkout_at else '—' }}</td>
+                            <td>{% if record.note == 'No check-in record found' %}{% elif record.note %}{{ record.note }}{% else %}—{% endif %}</td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="6">No snapshot records found for the selected period.</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/app/templates/staff/hr_login_summary_report.html
+++ b/app/templates/staff/hr_login_summary_report.html
@@ -510,19 +510,23 @@
                                     <span class="is-size-6">Dashboard</span>
                                 </span>
                             </div>
+                            <a class="panel-block" href="{{ url_for('staff.hr_daily_attendance_report') }}">
+                                <span>
+                                    <span class="icon"><i class="fas fa-chart-line" aria-hidden="true"></i></span>
+                                    <span class="is-size-6">Daily Attendance Statistics</span>
+                                </span>
+                            </a>
                             <a class="panel-block" href="{{ url_for('staff.hr_manual_checkin') }}">
                                 <span>
                                     <span class="icon"><i class="fas fa-map-marker-alt" aria-hidden="true"></i></span>
                                     <span class="is-size-6">Add Check-In</span>
                                 </span>
-                                <span class="icon"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                             </a>
                             <a class="panel-block" href="{{ url_for('staff.hr_checkin_requests') }}">
                                 <span>
                                     <span class="icon"><i class="fas fa-clipboard-check" aria-hidden="true"></i></span>
                                     <span class="is-size-6">Check-In Requests</span>
                                 </span>
-                                <span class="icon"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                             </a>
                             <a class="panel-block" href="{{ url_for('staff.for_hr') }}">
                                 <span>


### PR DESCRIPTION
Add a date-range snapshot statistics page with unit and staff-type filters, staff-level attendance summaries, source counts, and drill-down detail records. Link staff names to their snapshot history, present statuses as colored tags, and keep internal reconciliation text blank in the detail view.